### PR TITLE
Adding remote resources plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,24 @@
                     <pushChanges>false</pushChanges>
                 </configuration>
             </plugin>
+            <!-- We want to package up license resources in the JARs produced -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <resourceBundles>
+                                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
+                            </resourceBundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The `remote-resources` plugin is a handy plugin to include the following files into the `META-INF` folder of the JAR:
- license (the license of the code),
- notice (e.g. copyright notice)
- dependencies (contains a convenient list of used dependencies and their licenses)

See [AEROGEAR-1283](https://issues.jboss.org/browse/AEROGEAR-1283) as well
