### PR TITLE
Keycloak beta4 fix

### DIFF
--- a/aerogear-bom/pom.xml
+++ b/aerogear-bom/pom.xml
@@ -38,7 +38,7 @@
         <codehaus.jackson.version>1.9.9</codehaus.jackson.version>
         <ektorp.version>1.4.1</ektorp.version>
         <findbugs.version>2.0.3</findbugs.version>
-        <freemarker.version>2.3.19</freemarker.version>
+        <freemarker.version>2.3.20</freemarker.version>
         <hibernate.version>4.2.15.Final</hibernate.version>
         <hibernate-validator.version>4.3.1.Final</hibernate-validator.version>
         <iharder.version>2.3.8</iharder.version>


### PR DESCRIPTION
Fixed version of dependency org.freemarker, as adopted in KeycloakBeta4
