### PR TITLE
Removed scope from aerogear-bom

### DIFF
--- a/aerogear-bom/pom.xml
+++ b/aerogear-bom/pom.xml
@@ -328,14 +328,12 @@
               <groupId>org.jboss.resteasy</groupId>
               <artifactId>resteasy-jaxrs</artifactId>
               <version>${resteasy.version}</version>
-              <scope>provided</scope>
             </dependency>
 
             <dependency>
               <groupId>org.jboss.spec.javax.servlet</groupId>
               <artifactId>jboss-servlet-api_3.0_spec</artifactId>
               <version>${servlet.api.30.version}</version>
-              <scope>provided</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- See guidelines - no scope should be defined in BOMs (exception import)
