### PR TITLE
Removal of unexisting dependency

### DIFF
--- a/aerogear-bom/pom.xml
+++ b/aerogear-bom/pom.xml
@@ -173,11 +173,6 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-codec-sockjs</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
                 <version>${netty.version}</version>
             </dependency>


### PR DESCRIPTION
This artifact does not exist (it should rather be org.jboss.aerogear:aerogear-netty-codec-sockjs, from https://github.com/aerogear/aerogear-simplepush-server/commit/a45245728b57e39ae5f63e01aadc4cf0c3c6b6b4#diff-0bc5f6b3f39d5e616b16132668b36b8bL61).
It should be removed anyway, as we would not declare AeroGear dependencies into AeroGear BOMs
