### PR TITLE
Update to KeyCloak 1.2.0.CR1

### DIFF
--- a/aerogear-bom/pom.xml
+++ b/aerogear-bom/pom.xml
@@ -48,7 +48,7 @@
         <jboss.modules.version>1.1.1.GA</jboss.modules.version>
         <jedis.version>2.0.0</jedis.version>
         <json-simple.version>1.1</json-simple.version>
-        <keycloak.version>1.1.0.Final</keycloak.version>
+        <keycloak.version>1.2.0.CR1</keycloak.version>
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <netty.version>5.0.0.Alpha1</netty.version>
         <mysql.version>5.1.18</mysql.version>


### PR DESCRIPTION
This update is required to fix the issues described here: https://issues.jboss.org/browse/AGPUSH-1352.

Also, the sooner we test KeyCloak 1.2.0x, the better. I've already tested against our supported databases, seems to be working fine.

@matzew @sebastienblanc care to take a look?