### PR TITLE
Fix unused properties of httpcomponents

### DIFF
--- a/aerogear-bom/pom.xml
+++ b/aerogear-bom/pom.xml
@@ -52,7 +52,8 @@
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <netty.version>5.0.0.Alpha1</netty.version>
         <mysql.version>5.1.18</mysql.version>
-        <org.apache.httpcomponents.version>4.2.1</org.apache.httpcomponents.version>
+        <org.apache.httpcomponents.httpcore.version>4.3.3</org.apache.httpcomponents.httpcore.version>
+        <org.apache.httpcomponents.httpclient.version>4.3.6</org.apache.httpcomponents.httpclient.version>
         <org.bouncycastle.version>1.46</org.bouncycastle.version>
         <resteasy.version>2.3.7.Final</resteasy.version>
         <scprov-jdk15on.version>1.47.0.3</scprov-jdk15on.version>
@@ -313,12 +314,12 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>${org.apache.httpcomponents.version}</version>
+                <version>${org.apache.httpcomponents.httpcore.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>${org.apache.httpcomponents.version}</version>
+                <version>${org.apache.httpcomponents.httpclient.version}</version>
             </dependency>
 
             <!-- Keycloak section borrowed from project integrations on Keycloak -->


### PR DESCRIPTION
The existing property `org.apache.httpcomponents.version` for the version of org.apache.httpcomponents dependencies is not used anywhere. 

The AeroGear components that use org.apache.httpcomponents dependencies are:
* aerogear-unifiedpush-server
* java-mpns

which override the version inherited from the AeroGear BOM in the relevant modules:
* https://github.com/aerogear/aerogear-unifiedpush-server/blob/master/servers/auth-server/pom.xml#L74
* https://github.com/aerogear/aerogear-unifiedpush-server/blob/master/servers/auth-server/pom.xml#L80
* https://github.com/aerogear/aerogear-unifiedpush-server/blob/master/servers/ups-as7/pom.xml#L48
* https://github.com/aerogear/aerogear-unifiedpush-server/blob/master/servers/ups-as7/pom.xml#L54
* https://github.com/aerogear/aerogear-unifiedpush-server/blob/master/servers/ups-wildfly/pom.xml#L48
* https://github.com/aerogear/aerogear-unifiedpush-server/blob/master/servers/ups-wildfly/pom.xml#L54
* https://github.com/aerogear/java-mpns/blob/master/pom.xml#L27 (actually the AeroGear BOM is not used here)

This patch align the versions of org.apache.httpcomponents dependencies required from the AeroGear components, which then will be able to avoid the override.

@sebastienblanc @abstractj @lfryc wdyt?


