### PR TITLE
Using newer GCM, directly from Google

### DIFF
--- a/aerogear-bom/pom.xml
+++ b/aerogear-bom/pom.xml
@@ -39,7 +39,7 @@
         <ektorp.version>1.4.1</ektorp.version>
         <findbugs.version>2.0.3</findbugs.version>
         <freemarker.version>2.3.20</freemarker.version>
-        <gcm-server.version>1.0.2</gcm-server.version>
+        <gcm-server.version>1.0.0</gcm-server.version>
         <hibernate.version>4.2.15.Final</hibernate.version>
         <hibernate-validator.version>4.3.1.Final</hibernate-validator.version>
         <iharder.version>2.3.8</iharder.version>
@@ -124,7 +124,7 @@
             </dependency>
 
             <dependency>
-                <groupId>com.ganyo</groupId>
+                <groupId>com.google.gcm</groupId>
                 <artifactId>gcm-server</artifactId>
                 <version>${gcm-server.version}</version>
             </dependency>


### PR DESCRIPTION
there is an 'official' GCM lib now on maven central, hosted on GH: https://github.com/google/gcm

This already uses new endpoint APIs:
https://github.com/google/gcm/blob/master/client-libraries/java/rest-client/src/com/google/android/gcm/server/Constants.java#L26-L27

and has understanding of GCM3 topic:
https://github.com/google/gcm/blob/master/client-libraries/java/rest-client/src/com/google/android/gcm/server/Constants.java#L37
