### PR TITLE
AEROGEAR-696 add initial BOM for android SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 .project
 .vscode/
 .settings
+*.iml

--- a/aerogear-android-sdk-bom/pom.xml
+++ b/aerogear-android-sdk-bom/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright Red Hat, Inc., and individual contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.jboss.aerogear</groupId>
+    <artifactId>aerogear-android-sdk-bom</artifactId>
+    <version>1.1.7-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>JBoss AeroGear Android SDK BOM</name>
+    <description>Bill Of Materials for AeroGear Android SDK</description>
+    <url>http://aerogear.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!--  dependencies -->
+        <okhttp.version>3.9.1</okhttp.version>
+
+        <!-- test dependencies -->
+        <junit.version>4.12</junit.version>
+        <robolectric.version>3.6.1</robolectric.version>
+
+        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/
+        </jboss.releases.repo.url>
+        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/
+        </jboss.snapshots.repo.url>
+    </properties>
+
+    <developers>
+        <developer>
+            <id>aerogear</id>
+            <name>AeroGear Team</name>
+            <email>aerogear-dev@lists.jboss.org</email>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://git@github.com:aerogear/aerogear-parent.git</connection>
+        <developerConnection>scm:git:ssh://github.com:aerogear/aerogear-parent.git</developerConnection>
+        <url>git://github.com:aerogear/aerogear-parent.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <!--
+                CONVENTIONS:
+                - Dependencies must be SORTED ALPHABETICALLY on groupId (other forms of sorting were found to be unclear and ambiguous).
+                - Do not declare <scope> (exception: import) or <optional>: a child module will declare scope/optional itself.
+                - Always extract the version as a property.
+                - A element's inner order is <groupId>, <artifactId>, [<type>,] [<classifier>,] <version> (following Aether proper)
+                EXCEPTIONS:
+                - If there is the need to force a particular version of a dependency out from a set of transitive dependencies, the
+                  alphabetical ordering policy may be overridden.
+            -->
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.robolectric</groupId>
+                <artifactId>robolectric</artifactId>
+                <version>${robolectric.version}</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+    <distributionManagement>
+        <repository>
+            <id>jboss-releases-repository</id>
+            <name>JBoss Releases Repository</name>
+            <url>${jboss.releases.repo.url}</url>
+        </repository>
+        <snapshotRepository>
+            <id>jboss-snapshots-repository</id>
+            <name>JBoss Snapshots Repository</name>
+            <url>${jboss.snapshots.repo.url}</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     <modules>
         <module>aerogear-unifiedpush-bom</module>
         <module>aerogear-test-bom</module>
+        <module>aerogear-android-sdk-bom</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Initial BOM for the Android SDK. Currently this locks down the versions of three dependencies: okhttp, junit and robolectric.

I'm not quite sure if we should add libraries like android compat because they come from the classpath as far as i know. Open to suggestions.