### PR TITLE
Moving parent for support Java 9

### DIFF
--- a/aerogear-android-sdk-bom/pom.xml
+++ b/aerogear-android-sdk-bom/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.aerogear</groupId>
     <artifactId>aerogear-android-sdk-bom</artifactId>
-    <version>1.1.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>JBoss AeroGear Android SDK BOM</name>

--- a/aerogear-test-bom/pom.xml
+++ b/aerogear-test-bom/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.aerogear</groupId>
     <artifactId>aerogear-test-bom</artifactId>
-    <version>1.1.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>JBoss AeroGear Test Dependencies BOM</name>

--- a/aerogear-unifiedpush-bom/pom.xml
+++ b/aerogear-unifiedpush-bom/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.aerogear</groupId>
     <artifactId>aerogear-unifiedpush-bom</artifactId>
-    <version>1.1.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>JBoss AeroGear UnifiedPush BOM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.jboss.aerogear</groupId>
     <artifactId>aerogear-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>JBoss AeroGear</name>
     <description>
         Open Source Libraries for Mobile Connectivity

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>24</version>
+        <version>25</version>
     </parent>
 
     <scm>


### PR DESCRIPTION
starting w/ Parent-25, the jboss parent pom, did a massive update to include plugins that do support Java9 builds.

Here is the upstream commit on the jboss-parent:
https://github.com/jboss/jboss-parent-pom/commit/99ee3d27c8b7f2e5105d922499719b7bfb9785bd

