### PR TITLE
add json dependency, required for certain unit test scenarios

### DIFF
--- a/aerogear-android-sdk-bom/pom.xml
+++ b/aerogear-android-sdk-bom/pom.xml
@@ -47,6 +47,7 @@
         <android.support.test.espresso.version>3.0.1</android.support.test.espresso.version>
         <robolectric.version>3.6.1</robolectric.version>
         <mockito.version>2.10.0</mockito.version>
+        <json.version>20180130</json.version>
 
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/
         </jboss.releases.repo.url>
@@ -131,7 +132,13 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
-            </dependency>            
+            </dependency>
+
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${json.version}</version>
+            </dependency>
 
             <!-- Core -->
             <dependency>


### PR DESCRIPTION
Add org.json to the BOM. This is required for unit testing because otherwise Android's JSONObject cannot be used during unit tests (see: https://stackoverflow.com/questions/32385092/why-is-my-jsonobject-related-unit-test-failing/32822468, https://stackoverflow.com/questions/31777188/android-methods-are-not-mocked-when-using-mockito)