### PR TITLE
Update jackson version to 2.9.9 in BOM

### DIFF
--- a/aerogear-unifiedpush-bom/pom.xml
+++ b/aerogear-unifiedpush-bom/pom.xml
@@ -34,7 +34,7 @@
         <gcm-server.version>1.0.0</gcm-server.version>
         <hibernate.version>5.0.10.Final</hibernate.version>
         <hibernate-validator.version>5.3.5.Final</hibernate-validator.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <json-simple.version>1.1</json-simple.version>
         <keycloak.version>4.8.3.Final</keycloak.version>
         <servlet.api.31.version>1.0.0.Final</servlet.api.31.version>
@@ -51,7 +51,7 @@
         <developer>
             <id>aerogear</id>
             <name>AeroGear Team</name>
-            <email>aerogear-dev@lists.jboss.org</email>
+            <email>aerogear@googlegroups.com</email>
         </developer>
     </developers>
 
@@ -78,7 +78,7 @@
                 - Dependencies must be SORTED ALPHABETICALLY on groupId (other forms of sorting were found to be unclear and ambiguous).
                 - Do not declare <scope> (exception: import) or <optional>: a child module will declare scope/optional itself.
                 - Always extract the version as a property.
-                - A element's inner order is <groupId>, <artifactId>, [<type>,] [<classifier>,] <version> (following Aether proper)
+                - An element's inner order is <groupId>, <artifactId>, [<type>,] [<classifier>,] <version> (following Aether proper)
                 EXCEPTIONS:
                 - If there is the need to force a particular version of a dependency out from a set of transitive dependencies, the
                 alphabetical ordering policy may be overridden.
@@ -186,7 +186,7 @@
                 <version>${keycloak.version}</version>
             </dependency>
 
-            <!-- Required adatpers -->
+            <!-- Required adapters -->
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-adapter-core</artifactId>
@@ -213,7 +213,5 @@
             <url>${jboss.snapshots.repo.url}</url>
         </snapshotRepository>
     </distributionManagement>
-
-
 
 </project>

--- a/aerogear-unifiedpush-bom/pom.xml
+++ b/aerogear-unifiedpush-bom/pom.xml
@@ -59,8 +59,8 @@
         <connection>scm:git:git://git@github.com:aerogear/aerogear-parent.git</connection>
         <developerConnection>scm:git:ssh://github.com:aerogear/aerogear-parent.git</developerConnection>
         <url>git://github.com:aerogear/aerogear-parent.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <licenses>
         <license>
@@ -81,7 +81,7 @@
                 - A element's inner order is <groupId>, <artifactId>, [<type>,] [<classifier>,] <version> (following Aether proper)
                 EXCEPTIONS:
                 - If there is the need to force a particular version of a dependency out from a set of transitive dependencies, the
-                  alphabetical ordering policy may be overridden.
+                alphabetical ordering policy may be overridden.
             -->
 
             <dependency>
@@ -168,37 +168,37 @@
             </dependency>
 
             <dependency>
-              <groupId>org.jboss.resteasy</groupId>
-              <artifactId>resteasy-jaxrs</artifactId>
-              <version>${resteasy.version}</version>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jaxrs</artifactId>
+                <version>${resteasy.version}</version>
             </dependency>
 
             <dependency>
-              <groupId>org.jboss.spec.javax.servlet</groupId>
-              <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-              <version>${servlet.api.31.version}</version>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+                <version>${servlet.api.31.version}</version>
             </dependency>
 
             <!-- Required by ups-jaxrs module -->
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-core</artifactId>
-              <version>${keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-core</artifactId>
+                <version>${keycloak.version}</version>
             </dependency>
 
             <!-- Required adatpers -->
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-adapter-core</artifactId>
-              <version>${keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-core</artifactId>
+                <version>${keycloak.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.keycloak</groupId>
-              <artifactId>keycloak-wildfly-adapter</artifactId>
-              <version>${keycloak.version}</version>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-wildfly-adapter</artifactId>
+                <version>${keycloak.version}</version>
             </dependency>
 
-         </dependencies>
+        </dependencies>
     </dependencyManagement>
 
     <distributionManagement>


### PR DESCRIPTION
There are a couple of other minor changes to the same pom.xml file, so I've split the PR into two commits: the first only has whitespace changes, and the second has everything else (including the update to the new jackson version).